### PR TITLE
Add support for `dip` length

### DIFF
--- a/src/svgdom/length.cpp
+++ b/src/svgdom/length.cpp
@@ -63,6 +63,8 @@ length length::parse(std::string_view str){
 		ret.unit = length_unit::pt;
 	}else if(unit == "pc"){
 		ret.unit = length_unit::pc;
+	}else if(unit == "dip"){
+		ret.unit = length_unit::dip;
 	}else{
 		ret.unit = length_unit::unknown;
 	}
@@ -91,6 +93,8 @@ real length::to_px(real dpi) const noexcept{
 		case svgdom::length_unit::ex:
 			// em and ex depend on the font size. Text is not supported by svgdom, so return 0 size.
 			return 0;
+		case svgdom::length_unit::dip: // 1 px = 1/96 of an inch
+			return std::ceil(this->value * (dpi / real(96)));
 	}
 }
 
@@ -128,6 +132,9 @@ std::ostream& operator<<(std::ostream& s, const length& l){
 			break;
 		case length_unit::pc:
 			s << "pc";
+			break;
+		case length_unit::dip:
+			s << "dip";
 			break;
 	}
 	

--- a/src/svgdom/length.hpp
+++ b/src/svgdom/length.hpp
@@ -49,6 +49,11 @@ enum class length_unit{
 	pt,
 	pc,
 	mm,
+/*
+	dip is device independent pixels - logical units,inspired by Sciter.
+	1dip = 1/96 of inch therefore on 96DPI display this will be one pixel. On high-dpi screens it will be resolved to larger number of physical pixels.
+	For example: 2dip will take 3px on 120DPI screen. On printer 'dip' and 'px' units are equivalent.
+*/
 	dip
 };
 

--- a/src/svgdom/length.hpp
+++ b/src/svgdom/length.hpp
@@ -48,7 +48,8 @@ enum class length_unit{
 	in,
 	pt,
 	pc,
-	mm
+	mm,
+	dip
 };
 
 /**

--- a/tests/unit/samples_data/dip.svg
+++ b/tests/unit/samples_data/dip.svg
@@ -1,0 +1,7 @@
+<svg version="1.1" width="400dip" height="400dip" xmlns="http://www.w3.org/2000/svg">
+
+<circle class="class1" id="id1" cx="95dip" cy="45dip" r="25dip" fill="blue" />
+
+	<rect class="class2" id="id2" width="50dip" height="50dip" x="10dip" y="20dip" fill="red" />
+
+</svg>

--- a/tests/unit/samples_data/dip.svg.cmp
+++ b/tests/unit/samples_data/dip.svg.cmp
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="400dip" height="400dip">
+	<circle id="id1" fill="blue" class="class1" cx="95dip" cy="45dip" r="25dip"/>
+	<rect id="id2" fill="red" class="class2" x="10dip" y="20dip" width="50dip" height="50dip"/>
+</svg>


### PR DESCRIPTION
`dip` is device independent pixels - logical units. 1dip = 1/96 of inch therefore on 96DPI display this will be one pixel. On high-dpi screens it will be resolved to larger number of physical pixels. For example: 2dip will take 3px on 120DPI screen. On printer 'dip' and 'px' units are equivalent.

Inspired by Sciter, see: https://github.com/c-smile/sciter-js-sdk/tree/main/docs/md/css